### PR TITLE
update dynamic port range to 32768-60999.

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -100,8 +100,8 @@ nacl_rules = [
     protocol    = "tcp"
     rule_action = "allow"
     cidr_block  = "0.0.0.0/0"
-    from_port   = 49152
-    to_port     = 65535
+    from_port   = 32768
+    to_port     = 60999
     icmp_type   = null
     icmp_code   = null
   },


### PR DESCRIPTION
Ephermal/dynamic port range on current (ami-09e5afc68eed60ef4) centos7
ami is: 32768-60999. This range does not meet IANA recommendation range:
49152-65535, which has been set in network ACL rules therefore internet
was unavailable.